### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-centos.yaml
+++ b/.github/workflows/docker-centos.yaml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish Centos version to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.6
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rkhozinov/docker-percona-xtrabackup/centos
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker-debian.yaml
+++ b/.github/workflows/docker-debian.yaml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish Debian version to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.6
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rkhozinov/docker-percona-xtrabackup/debian
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore